### PR TITLE
Added missing public declaration

### DIFF
--- a/Sources/UserDefaultObservation/UserDefaultObservation.swift
+++ b/Sources/UserDefaultObservation/UserDefaultObservation.swift
@@ -36,7 +36,7 @@ public final class UserDefaultObservation: NSObject {
         invalidate()
     }
 
-    func invalidate() {
+    public func invalidate() {
         guard !isObserverRemoved else { return }
         isObserverRemoved = true
         userDefaults.removeObserver(self, forKeyPath: key)

--- a/Sources/UserDefaultObservation/UserDefaultObservedChange.swift
+++ b/Sources/UserDefaultObservation/UserDefaultObservedChange.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public struct UserDefaultObservedChange<Value> {
-    let kind: NSKeyValueChange
-    let indices: IndexSet?
-    let isPrior: Bool
-    let oldValue: Value?
-    let newValue: Value?
+    public let kind: NSKeyValueChange
+    public let indices: IndexSet?
+    public let isPrior: Bool
+    public let oldValue: Value?
+    public let newValue: Value?
 
     init(_ change: [NSKeyValueChangeKey: Any]) {
         kind = NSKeyValueChange(rawValue: change[.kindKey] as! UInt)!

--- a/Sources/UserDefaultsStorable.swift
+++ b/Sources/UserDefaultsStorable.swift
@@ -69,7 +69,7 @@ public extension UserDefaultsStorable where Self: Codable {
     }
 }
 
-extension UserDefaultsStorable where Self: RawRepresentable, RawValue: UserDefaultsStorable {
+public extension UserDefaultsStorable where Self: RawRepresentable, RawValue: UserDefaultsStorable {
     static var userDefaultsBridge: UserDefaultsBridge<Self> {
         UserDefaultsBridge(
             serialization: { $0?.rawValue },
@@ -81,7 +81,7 @@ extension UserDefaultsStorable where Self: RawRepresentable, RawValue: UserDefau
     }
 }
 
-extension UserDefaultsStorable where Self: Codable, Self: RawRepresentable, RawValue: UserDefaultsStorable {
+public extension UserDefaultsStorable where Self: Codable, Self: RawRepresentable, RawValue: UserDefaultsStorable {
     static var userDefaultsBridge: UserDefaultsBridge<Self> {
         UserDefaultsBridge(
             serialization: { $0?.rawValue },

--- a/Tests/UserDefaultsStorableTests/UserDefaultsStorableTests.swift
+++ b/Tests/UserDefaultsStorableTests/UserDefaultsStorableTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import UserDefaultsStorable
+import UserDefaultsStorable
 
 final class UserDefaultsStorableTests: XCTestCase {
 


### PR DESCRIPTION
Some properties and extension were marked as internal. Now `enum` with `RawValue` can be used as expected.